### PR TITLE
fix: guard against empty/filtered LLM responses

### DIFF
--- a/002-stride-swarm-crawl4ai-marketing-agent/main.py
+++ b/002-stride-swarm-crawl4ai-marketing-agent/main.py
@@ -100,7 +100,10 @@ def generate_completion(role, task, content):
     )
     if not response.choices or response.choices[0].message is None:
         raise ValueError("LLM returned empty or filtered response")
-    return response.choices[0].message.content
+    text = response.choices[0].message.content
+    if not text:
+        raise ValueError("LLM returned empty or filtered response")
+    return text
 
 # Function to analyze website content
 def analyze_website_content(content):

--- a/002-stride-swarm-crawl4ai-marketing-agent/main.py
+++ b/002-stride-swarm-crawl4ai-marketing-agent/main.py
@@ -98,6 +98,8 @@ def generate_completion(role, task, content):
             {"role": "user", "content": content}
         ]
     )
+    if not response.choices or response.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     return response.choices[0].message.content
 
 # Function to analyze website content

--- a/002-stride-swarm-crawl4ai-marketing-agent/swarm-examples/customer_service_streaming/src/evals/eval_function.py
+++ b/002-stride-swarm-crawl4ai-marketing-agent/swarm-examples/customer_service_streaming/src/evals/eval_function.py
@@ -55,6 +55,8 @@ class EvalFunction:
     if not completion_result.choices or completion_result.choices[0].message is None:
         raise ValueError("LLM returned empty or filtered response")
     name_extract = completion_result.choices[0].message.content
+    if not name_extract:
+        raise ValueError("LLM returned empty or filtered response")
     print(f"Name extracted: {name_extract}")
     try:
        names = ast.literal_eval(name_extract)

--- a/002-stride-swarm-crawl4ai-marketing-agent/swarm-examples/customer_service_streaming/src/evals/eval_function.py
+++ b/002-stride-swarm-crawl4ai-marketing-agent/swarm-examples/customer_service_streaming/src/evals/eval_function.py
@@ -52,6 +52,8 @@ class EvalFunction:
          },
          {"role": "user", "content": f"SENTENCE:\n{response}"}]
     )
+    if not completion_result.choices or completion_result.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     name_extract = completion_result.choices[0].message.content
     print(f"Name extracted: {name_extract}")
     try:


### PR DESCRIPTION
## What

Add null checks before accessing `choices[0].message.content` in two call sites.

**Files changed:**
- `002-stride-swarm-crawl4ai-marketing-agent/main.py` (`generate_completion`)
- `swarm-examples/customer_service_streaming/src/evals/eval_function.py` (`EvalFunction.name`)

## Why

The OpenAI SDK can return an empty `choices` list (e.g. on network interruption or rate-limit edge cases), which causes an `IndexError`. Some providers (Gemini via the OpenAI-compatible endpoint) return HTTP 200 with `choices[0].message = None` on content-filtered responses, causing an `AttributeError`.

The guard pattern:
```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```
converts both silent crashes into a clear, actionable error message.

## Test

No automated tests cover these paths; the fix is a defensive pre-condition check that does not change behaviour for well-formed responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented comprehensive error validation in critical operations to detect and report incomplete or malformed data before processing. The system now catches these issues immediately with clear error messages instead of failing silently, preventing downstream problems and significantly enhancing system reliability and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/joshpocock/Stride-AI-Agents/pull/3?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->